### PR TITLE
Fix hooks (and hook crimes)

### DIFF
--- a/Code/Triggers/RunAndGunTrigger.cs
+++ b/Code/Triggers/RunAndGunTrigger.cs
@@ -14,14 +14,17 @@ namespace Celeste.Mod.AidenHelper.Triggers
     {
         private static Hook hookDuckingGetter;
         private static ILHook hookDashCoroutine;
+        private static ILHook hookPlayerUpdate;
 
         public static void Load()
         {
             IL.Celeste.Player.NormalUpdate += modPlayerNormalUpdate;
             IL.Celeste.Player.DashUpdate += modPlayerDashUpdate;
-            IL.Celeste.Player.Update += modPlayerUpdate;
             On.Celeste.Player.Die += modPlayerDie;
 
+            hookPlayerUpdate = new ILHook(
+                typeof(Player).GetMethod("orig_Update", BindingFlags.Public | BindingFlags.Instance),
+                modPlayerUpdate);
             hookDuckingGetter = new Hook(
                 typeof(Player).GetMethod("get_Ducking"),
                 typeof(RunAndGunTrigger).GetMethod("modDuckingGetter", BindingFlags.NonPublic | BindingFlags.Static));
@@ -34,11 +37,12 @@ namespace Celeste.Mod.AidenHelper.Triggers
         {
             IL.Celeste.Player.NormalUpdate -= modPlayerNormalUpdate;
             IL.Celeste.Player.DashUpdate -= modPlayerDashUpdate;
-            IL.Celeste.Player.Update -= modPlayerUpdate;
             On.Celeste.Player.Die -= modPlayerDie;
 
+            hookPlayerUpdate?.Dispose();
             hookDuckingGetter?.Dispose();
             hookDashCoroutine?.Dispose();
+            hookPlayerUpdate = null;
             hookDuckingGetter = null;
             hookDashCoroutine = null;
         }
@@ -49,18 +53,16 @@ namespace Celeste.Mod.AidenHelper.Triggers
 
             Logger.Log("AidenHelper/RunAndGunTrigger", $"Modding player normal update at {cursor.Index} in IL for {il.Method.FullName}");
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.EmitDelegate<Action<Player>>(player => {
-                if (Module.AidenHelper.Instance.Session.RunAndGunEnabled)
-                {
-                    player.moveX = Module.AidenHelper.Instance.Session.RunAndGunMoveX;
-                    player.Facing = (Facings)player.moveX;
-                }
-            });
-            while (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchLdcR4(1.4f) || instr.MatchLdcR4(0.6f)))
+            cursor.EmitDelegate<Action<Player>>(OverrideMoveXAndFacing);
+
+            while (cursor.TryGotoNext(MoveType.After,
+                instr => instr.MatchLdfld<Player>("Sprite"),
+                instr => instr.MatchLdcR4(0.6f),
+                instr => instr.MatchLdcR4(1.4f),
+                instr => instr.MatchNewobj<Vector2>()))
             {
                 Logger.Log("AidenHelper/RunAndGunTrigger", $"Unsquishing sprite at {cursor.Index} in CIL code for {cursor.Method.FullName}");
-                cursor.Remove();
-                cursor.Emit(OpCodes.Ldc_R4, 1f);
+                cursor.EmitDelegate<Func<Vector2, Vector2>>(OverrideSquishFactor);
             }
         }
 
@@ -68,16 +70,12 @@ namespace Celeste.Mod.AidenHelper.Triggers
         {
             ILCursor cursor = new ILCursor(il);
 
-            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchStfld<Player>("Dashdir")))
+            while (cursor.TryGotoNext(MoveType.Before, 
+                instr => instr.MatchStfld<Player>("DashDir")))
             {
                 Logger.Log("AidenHelper/RunAndGunTrigger", $"Altering player DashDir at {cursor.Index} in IL for {cursor.Method.FullName}");
-                cursor.EmitDelegate<Action<Player>>(player =>
-                {
-                    if (Module.AidenHelper.Instance.Session.RunAndGunEnabled)
-                    {
-                        player.DashDir = new Vector2((Module.AidenHelper.Instance.Session.RunAndGunMoveX == 1) ? 1 : -1 * Math.Abs(player.DashDir.X), player.DashDir.Y);
-                    }
-                });
+                cursor.EmitDelegate<Func<Vector2, Vector2>>(OverrideDashDir);
+                cursor.Index++;
             }
         }
 
@@ -85,54 +83,37 @@ namespace Celeste.Mod.AidenHelper.Triggers
         {
             ILCursor cursor = new ILCursor(il);
 
-            while (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchLdfld<Player>("moveX")))
+            while (cursor.TryGotoNext(MoveType.After, 
+                instr => instr.MatchLdfld<Player>("moveX")))
             {
                 Logger.Log("AidenHelper/RunAndGunTrigger", $"Altering player moveX at {cursor.Index} in IL for {cursor.Method.FullName}");
-                cursor.Remove();
-                cursor.EmitDelegate<Func<Player, int>>(player =>
-                {
-                    if (Module.AidenHelper.Instance.Session.RunAndGunEnabled)
-                    {
-                        return Module.AidenHelper.Instance.Session.RunAndGunMoveX * player.moveX;
-                    }
-                    return player.moveX;
-                });
+                cursor.EmitDelegate<Func<int, int>>(OverrideLoadedMoveX);
             }
         }
 
-        public static PlayerDeadBody modPlayerDie(On.Celeste.Player.orig_Die orig, Player self, Vector2 v1, bool v2, bool v3)
+        public static PlayerDeadBody modPlayerDie(On.Celeste.Player.orig_Die orig, Player self, Vector2 direction, bool evenIfInvincible, bool registerDeathInStats)
         {
             Module.AidenHelper.Instance.Session.RunAndGunEnabled = false;
-            return orig(self, v1, v2, v3);
+            return orig(self, direction, evenIfInvincible, registerDeathInStats);
         }
 
-        private static bool modDuckingGetter(Func<Player, bool> orig, Player self)
-        {
-            if (Module.AidenHelper.Instance.Session.RunAndGunEnabled && self.StateMachine == Player.StNormal)
-            {
-                return false;
-            }
-            return orig(self);
-        }
+        private static bool modDuckingGetter(Func<Player, bool> orig, Player self) =>
+            (Module.AidenHelper.Instance.Session.RunAndGunEnabled && self.StateMachine == Player.StNormal)
+                ? false 
+                : orig(self);
 
         private static void ilHookDashCoroutine(ILContext il)
         {
             ILCursor cursor = new ILCursor(il);
 
+            if (!cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdfld<Player>("lastAim")))
+            {
+                Logger.Log(LogLevel.Error, "AidenHelper/RunAndGunTrigger", $"Could not mod player dash coroutine in IL for {il.Method.FullName}");
+                return;
+            }
             Logger.Log("AidenHelper/RunAndGunTrigger", $"Modding player dash coroutine at {cursor.Index} in IL for {il.Method.FullName}");
-            cursor.TryGotoNext(MoveType.Before, instr => instr.MatchLdfld<Player>("lastAim"));
-            cursor.Remove();
-            cursor.EmitDelegate<Func<Player, Vector2>>(player => {
-                if (Module.AidenHelper.Instance.Session.RunAndGunEnabled)
-                {
-                    if (player.moveX == -Module.AidenHelper.Instance.Session.RunAndGunMoveX)
-                    {
-                        // Changes lastAim to act as if the opposite direction is not being held
-                        return new Vector2((player.lastAim.Y == 0) ? Module.AidenHelper.Instance.Session.RunAndGunMoveX : 0, player.lastAim.Y);
-                    }
-                }
-                return player.lastAim;
-            });
+            cursor.Emit(OpCodes.Ldloc_1);
+            cursor.EmitDelegate<Func<Vector2, Player, Vector2>>(OverrideLastAim);
         }
 
         private bool enableRunAndGun;
@@ -141,7 +122,7 @@ namespace Celeste.Mod.AidenHelper.Triggers
         public RunAndGunTrigger(EntityData data, Vector2 offset) : base(data, offset)
         {
             enableRunAndGun = data.Bool("enable", true);
-            moveDirection = data.Bool("facingRight", true) ? 1: -1;
+            moveDirection = data.Bool("facingRight", true) ? 1 : -1;
         }
 
         public override void OnEnter(Player player)
@@ -149,10 +130,39 @@ namespace Celeste.Mod.AidenHelper.Triggers
             base.OnEnter(player);
 
             Module.AidenHelper.Instance.Session.RunAndGunEnabled = enableRunAndGun;
+
             if (enableRunAndGun)
-            {
                 Module.AidenHelper.Instance.Session.RunAndGunMoveX = moveDirection;
-            }
         }
+
+        private static Vector2 OverrideSquishFactor(Vector2 @default)
+            => Module.AidenHelper.Instance.Session.RunAndGunEnabled 
+                ? Vector2.One
+                : @default;
+
+        private static void OverrideMoveXAndFacing(Player player)
+        {
+            if (!Module.AidenHelper.Instance.Session.RunAndGunEnabled)
+                return;
+
+            player.moveX = Module.AidenHelper.Instance.Session.RunAndGunMoveX;
+            player.Facing = (Facings)player.moveX;
+        }
+
+        private static Vector2 OverrideDashDir(Vector2 @default) =>
+            Module.AidenHelper.Instance.Session.RunAndGunEnabled
+                ? new Vector2(((Module.AidenHelper.Instance.Session.RunAndGunMoveX == 1) ? 1 : -1) * Math.Abs(@default.X), @default.Y)
+                : @default;
+
+        private static int OverrideLoadedMoveX(int @default) =>
+            Module.AidenHelper.Instance.Session.RunAndGunEnabled
+                ? Module.AidenHelper.Instance.Session.RunAndGunMoveX * @default
+                : @default;
+
+        private static Vector2 OverrideLastAim(Vector2 @default, Player player) =>
+            (Module.AidenHelper.Instance.Session.RunAndGunEnabled && player.moveX == -Module.AidenHelper.Instance.Session.RunAndGunMoveX)
+                // Changes lastAim to act as if the opposite direction is not being held
+                ? new Vector2((@default.Y == 0) ? Module.AidenHelper.Instance.Session.RunAndGunMoveX : 0, @default.Y)
+                : @default;
     }
 }


### PR DESCRIPTION
This helper's `RunAndGunTrigger` has multiple IL hooks which fail to do anything, misbehave, and/or use bad practices, causing it to not work as expected or modify parts of the game in unexpected ways.

https://github.com/CaptainCarpensir/AidenHelper/blob/32adff4a075df249d617a03e20357be5051d57fb/Code/Triggers/RunAndGunTrigger.cs#L59-L64
This `Player.NormalUpdate` hook replaces **every single `1.4f` or `0.6f` constant** with `1.0f`. While it achieves its goal, it also **completely negates space gravity** (last rooms of 8A, 8B + many modded maps), and sets `wallSlideTimer` to `1.0f`, which is outside its intended range.
This is **very** bad practice, as it makes some maps impossible. Care should be taken to replace **only** the instructions you intended to replace.

Additionally, it completely negates the crouch squish, **even if the trigger is not active**. I added a `RunAndGunEnabled` check in the settings to only disable the squish when the trigger is active.

https://github.com/CaptainCarpensir/AidenHelper/blob/32adff4a075df249d617a03e20357be5051d57fb/Code/Triggers/RunAndGunTrigger.cs#L71-L81
This `Player.DashUpdate` hook fails completely due to a typo: `Dashdir` instead of `DashDir`.

https://github.com/CaptainCarpensir/AidenHelper/blob/32adff4a075df249d617a03e20357be5051d57fb/Code/Triggers/RunAndGunTrigger.cs#L88-L99
This `Player.Update` hook also fails completely, as `Player.Update` makes no mention of `Player.moveX`. You're looking for `Player.orig_Update`. This requires manually constructing an `ILHook`.

https://github.com/CaptainCarpensir/AidenHelper/blob/32adff4a075df249d617a03e20357be5051d57fb/Code/Triggers/RunAndGunTrigger.cs#L122-L135
This `Player.DashCoroutine` hook does not check whether `cursor.TryGotoNext` has succeeded. If `cursor.TryGotoNext` fails, the instructions are still emitted, causing an `InvalidProgramException`.

Using `cursor.Remove` is bad practice. If other mods are looking for a sequence of instructions you removed, they can fail to hook and either fail or crash the game at hook-time.

While technically fine on their own, using inline delegates in `cursor.EmitDelegate` is suboptimal. I replaced those with a method group, which is the optimal way to go.

---

Modifying vanilla behavior without warning is frowned upon (especially when it's in subtle ways) and can cause major headaches debugging.  
Please update the helper when possible.